### PR TITLE
Make changes to attackby procs for /planet turfs

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -147,7 +147,7 @@
 	var/obj/item/weapon/crowbar/CB = user.is_holding_item_of_type(/obj/item/weapon/crowbar)
 	if(!CB)
 		return
-	var/turf/open/floor/plating/P = pry_tile(CB, user, TRUE)
+	var/turf/open/floor/planet/dirt/P = pry_tile(CB, user, TRUE)
 	if(!istype(P))
 		return
 	P.attackby(T, user, params)

--- a/code/game/turfs/simulated/planet.dm
+++ b/code/game/turfs/simulated/planet.dm
@@ -3,6 +3,27 @@
 	initial_gas_mix = PLANET_DEFAULT_ATMOS
 	planetary_atmos = TRUE
 
+/turf/open/floor/planet/attackby(obj/item/C, mob/user, params)
+	if(istype(C, /obj/item/stack/tile))
+		if(!broken && !burnt)
+			var/obj/item/stack/tile/W = C
+			if(!W.use(1))
+				return
+			var/turf/open/floor/T = ChangeTurf(W.turf_type)
+			if(istype(W, /obj/item/stack/tile/light)) //TODO: get rid of this ugly check somehow
+				var/obj/item/stack/tile/light/L = W
+				var/turf/open/floor/light/F = T
+				F.state = L.state
+			playsound(src, 'sound/weapons/genhit.ogg', 50, 1)
+	else if(istype(C, /obj/item/weapon/crowbar))
+		return
+	else if(istype(C, /obj/item/weapon/shovel) && params)
+		return
+	else
+		..()
+
+////////////GRASS///////////////
+
 /turf/open/floor/planet/grass
 	icon_state = "grass"
 	var/ore_type = /obj/item/weapon/ore/glass
@@ -16,24 +37,82 @@
 			new ore_type(src) //Make some sand if you shovel grass
 			user.visible_message("<span class='notice'>[user] digs up [src].</span>", "<span class='notice'>You [src.turfverb] [src].</span>")
 			make_plating()
-	if(..())
-		return
+	else
+		..()
+
+/////////////DIRT///////////
 
 /turf/open/floor/planet/dirt
 
 /turf/open/floor/planet/greenerdirt
 	icon_state = "greenerdirt"
+	var/ore_type = /obj/item/weapon/ore/glass
+	var/turfverb = "uproot"
+
+/turf/open/floor/planet/greenerdirt/attackby(obj/item/C, mob/user, params)
+	if(istype(C, /obj/item/weapon/shovel) && params)
+		playsound(src, 'sound/effects/shovel_dig.ogg', 50, 1)
+		if(do_after(user, 20, target = src))
+			new ore_type(src)
+			new ore_type(src) //Make some sand if you shovel grass
+			user.visible_message("<span class='notice'>[user] digs up [src].</span>", "<span class='notice'>You [src.turfverb] [src].</span>")
+			make_plating()
+	else
+		..()
+
+///////////WOOD////////////
 
 /turf/open/floor/planet/wood
 	icon_state = "wood"
 	floor_tile = /obj/item/stack/tile/wood
 	broken_states = list("wood-broken", "wood-broken2", "wood-broken3", "wood-broken4", "wood-broken5", "wood-broken6", "wood-broken7")
 
+/turf/open/floor/planet/wood/attackby(obj/item/C, mob/user, params)
+	if(istype(C, /obj/item/weapon/screwdriver))
+		pry_tile(C, user)
+		return
+	else if(intact && istype(C, /obj/item/weapon/crowbar))
+		return pry_tile(C, user)
+	else if(istype(C, /obj/item/stack/tile))
+		return
+	else
+		..()
+
+///////////SAND///////////
+
 /turf/open/floor/planet/sand
 	icon_state = "sand"
+	var/ore_type = /obj/item/weapon/ore/glass
+	var/turfverb = "dig up"
+
+/turf/open/floor/planet/sand/attackby(obj/item/C, mob/user, params)
+	if(istype(C, /obj/item/weapon/shovel) && params)
+		playsound(src, 'sound/effects/shovel_dig.ogg', 50, 1)
+		if(do_after(user, 20, target = src))
+			new ore_type(src)
+			new ore_type(src) //Make some sand if you shovel grass
+			user.visible_message("<span class='notice'>[user] digs up [src].</span>", "<span class='notice'>You [src.turfverb] [src].</span>")
+			make_plating()
+	else
+		..()
 
 /turf/open/floor/planet/fine_sand
 	icon_state = "asteroid"
+	var/ore_type = /obj/item/weapon/ore/glass
+	var/turfverb = "dig up"
+
+/turf/open/floor/planet/fine_sand/attackby(obj/item/C, mob/user, params)
+	if(istype(C, /obj/item/weapon/shovel) && params)
+		playsound(src, 'sound/effects/shovel_dig.ogg', 50, 1)
+		if(do_after(user, 20, target = src))
+			new ore_type(src)
+			new ore_type(src) //Make some sand if you shovel grass
+			user.visible_message("<span class='notice'>[user] digs up [src].</span>", "<span class='notice'>You [src.turfverb] [src].</span>")
+			make_plating()
+	else
+		..()
+
+//////////WALLS//////////
 
 /turf/closed/wall/planet
 	initial_gas_mix = PLANET_DEFAULT_ATMOS


### PR DESCRIPTION
Overrides the default attackby proc for ``/planet`` turfs to change interactivity with them.

``/planet`` turfs now have the following ``/attackby`` characteristics by **default**:
- Tiles will interact with turfs and can be laid over them.
- Crowbars will not interact with turfs.
- Shovels/spades will not interact.

Some overrides of particular ``/planet`` turfs:
``planet/wood`` - no interactivity with tiles, crowbars and screwdrivers will remove the tile.

The following types can all be interacted with by a shovel/spade:
``planet/grass``
``planet/sand``
``planet/fine_sand``
``planet/greener_dirt``

Shovel/spade interactivity could be added into the ``/planet`` attackby proc by default but the number of ``/planet`` turfs that should not be diggable to those that should be is currently about the same.